### PR TITLE
Fix public accessibility of LaunchOutput member variables

### DIFF
--- a/app/src/main/java/decide/launch/LaunchOutput.java
+++ b/app/src/main/java/decide/launch/LaunchOutput.java
@@ -3,9 +3,9 @@ package decide.launch;
 // immutable class
 // member variables represent the output variables of the decide function
 public final class LaunchOutput {
-    private final boolean[] CMV;
-    private final boolean[][] PUM;
-    private final boolean[] FUV;
+    public final boolean[] CMV;
+    public final boolean[][] PUM;
+    public final boolean[] FUV;
 
     public LaunchOutput(boolean[] CMV,
                         boolean[][] PUM,


### PR DESCRIPTION
These need to be publically visible for testing.

resolve #69 